### PR TITLE
CATL-1237: Make user menu configurable

### DIFF
--- a/settings/Usermenu.setting.php
+++ b/settings/Usermenu.setting.php
@@ -1,0 +1,19 @@
+<?php
+
+return [
+  'allowCivicrmUserMenu' => [
+    'group_name' => 'CiviCRM Preferences',
+    'group' => 'core',
+    'name' => 'allowCivicrmUserMenu',
+    'type' => 'Boolean',
+    'quick_form_type' => 'YesNo',
+    'default' => TRUE,
+    'html_type' => 'radio',
+    'add' => '4.7',
+    'title' => 'Show user menu',
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'description' => 'The user menu is optional to aid navigation; if you would like to show the user menu, select yes, otherwise select no.',
+    'help_text' => '',
+  ],
+];

--- a/templates/CRM/Usermenu/Admin/Form/Settings.tpl
+++ b/templates/CRM/Usermenu/Admin/Form/Settings.tpl
@@ -1,0 +1,9 @@
+<tr class="crm-case-form-block-allowCaseLocks">
+  <td class="label">{$form.allowCivicrmUserMenu.label}</td>
+  <td>
+    {$form.allowCivicrmUserMenu.html}
+    <br />
+    <span class="description">{ts}The user menu is optional to aid navigation;
+    if you would like to show the user menu, select yes, otherwise select no.{/ts}</span>
+  </td>
+</tr>

--- a/usermenu.php
+++ b/usermenu.php
@@ -147,8 +147,8 @@ function usermenu_civicrm_themes(&$themes) {
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterContent/
  */
-function usermenu_civicrm_alterContent (&$content, $context, $templateName, $form) {
-  $isViewingMiscSettingsForm = get_class($form) === CRM_Admin_Form_Setting_Miscellaneous::class;
+function usermenu_civicrm_alterContent (&$content, $context, $templateName, $object) {
+  $isViewingMiscSettingsForm = get_class($object) === CRM_Admin_Form_Setting_Miscellaneous::class;
 
   if (!$isViewingMiscSettingsForm) {
     return;

--- a/usermenu.php
+++ b/usermenu.php
@@ -195,7 +195,10 @@ function usermenu_civicrm_alterContent (&$content, $context, $templateName, $for
  * Implements hook_civicrm_coreResourceList().
  */
 function usermenu_civicrm_coreResourceList(&$items, $region) {
-  if ($region == 'html-header') {
+  $allowCiviCrmUserMenu = (bool) Civi::settings()->get('allowCivicrmUserMenu');
+  $isHeaderRegion = $region === 'html-header';
+
+  if ($isHeaderRegion && $allowCiviCrmUserMenu) {
     CRM_Core_Resources::singleton()->addScriptFile('uk.co.compucorp.usermenu', 'js/usermenu.js', 1010);
     CRM_Core_Resources::singleton()->addStyleFile('uk.co.compucorp.usermenu', 'css/usermenu.min.css', 100, 'html-header');
   }

--- a/usermenu.php
+++ b/usermenu.php
@@ -170,6 +170,28 @@ function usermenu_civicrm_navigationMenu(&$menu) {
 } // */
 
 /**
+ * Implements hook_civicrm_alterContent().
+ * Adds extra settings fields to the Civicase Admin Settings form.
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterContent/
+ */
+function usermenu_civicrm_alterContent (&$content, $context, $templateName, $form) {
+  $isViewingMiscSettingsForm = get_class($form) === CRM_Admin_Form_Setting_Miscellaneous::class;
+
+  if (!$isViewingMiscSettingsForm) {
+    return;
+  }
+
+  $settingsTemplate = &CRM_Core_Smarty::singleton();
+  $settingsTemplateHtml = $settingsTemplate->fetchWith('CRM/Usermenu/Admin/Form/Settings.tpl', []);
+
+  $doc = phpQuery::newDocumentHTML($content);
+  $doc->find('table.form-layout:eq(1) tr:last')->append($settingsTemplateHtml);
+
+  $content = $doc->getDocument();
+}
+
+/**
  * Implements hook_civicrm_coreResourceList().
  */
 function usermenu_civicrm_coreResourceList(&$items, $region) {
@@ -177,4 +199,20 @@ function usermenu_civicrm_coreResourceList(&$items, $region) {
     CRM_Core_Resources::singleton()->addScriptFile('uk.co.compucorp.usermenu', 'js/usermenu.js', 1010);
     CRM_Core_Resources::singleton()->addStyleFile('uk.co.compucorp.usermenu', 'css/usermenu.min.css', 100, 'html-header');
   }
+}
+
+/**
+ * Implements hook_civicrm_preProcess().
+ */
+function usermenu_civicrm_preProcess($formName, &$form) {
+  $isViewingMiscSettingsForm = $formName === CRM_Admin_Form_Setting_Miscellaneous::class;
+
+  if (!$isViewingMiscSettingsForm) {
+    return;
+  }
+
+  $settings = $form->getVar('_settings');
+  $settings['allowCivicrmUserMenu'] = CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME;
+
+  $form->setVar('_settings', $settings);
 }

--- a/usermenu.php
+++ b/usermenu.php
@@ -141,34 +141,6 @@ function usermenu_civicrm_themes(&$themes) {
   _usermenu_civix_civicrm_themes($themes);
 }
 
-// --- Functions below this ship commented out. Uncomment as required. ---
-
-/**
- * Implements hook_civicrm_preProcess().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_preProcess
- *
-function usermenu_civicrm_preProcess($formName, &$form) {
-
-} // */
-
-/**
- * Implements hook_civicrm_navigationMenu().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_navigationMenu
- *
-function usermenu_civicrm_navigationMenu(&$menu) {
-  _usermenu_civix_insert_navigation_menu($menu, 'Mailings', array(
-    'label' => E::ts('New subliminal message'),
-    'name' => 'mailing_subliminal_message',
-    'url' => 'civicrm/mailing/subliminal',
-    'permission' => 'access CiviMail',
-    'operator' => 'OR',
-    'separator' => 0,
-  ));
-  _usermenu_civix_navigationMenu($menu);
-} // */
-
 /**
  * Implements hook_civicrm_alterContent().
  * Adds extra settings fields to the Civicase Admin Settings form.


### PR DESCRIPTION
## Overview

This PR allows the user menu introduced in #1 to be configurable so administrators can control showing or hiding this new menu.

⚠️ Note: the original PR can be found at https://github.com/reneolivo/uk.co.compucorp.usermenu/pull/2

## Before
![Misc  Undelete  PDFs  Limits  Logging  Captcha  etc     CiviCase](https://user-images.githubusercontent.com/1642119/76046007-1a74f780-5f35-11ea-91cf-734926c992d5.png)
(the option does not exist)

## After
![pr-after](https://user-images.githubusercontent.com/1642119/76045932-daae1000-5f34-11ea-8604-9fe4aa48219a.gif)

## Technical details

In order to add this new field to the miscellaneous settings we followed the steps in https://github.com/compucorp/uk.co.compucorp.civicase/pull/71

The only change of note is the `table.form-layout:eq(1) tr:last` selector. This was chosen because there is no reference to select a specific table where to place the new field so `:eq(1)` was needed instead of a more specific ID or class. Also, we didn't add the field as the last element in the form to avoid mixing it with the ReCAPTCHA settings fields.