### PR TITLE
CATL-1224: Fix error when deploying site

### DIFF
--- a/CRM/Usermenu/Page/UserMenu.php
+++ b/CRM/Usermenu/Page/UserMenu.php
@@ -48,7 +48,7 @@ class CRM_Usermenu_Page_UserMenu extends CRM_Core_Page {
    */
   private function getDefaultImagePath() {
     $modulePath = (new CRM_Extension_System())
-      ->getDefaultContainer()
+      ->getFullContainer()
       ->getResUrl('uk.co.compucorp.usermenu');
 
     return str_replace('%{base}', $modulePath, self::DEFAULT_USER_IMAGE_PATH);


### PR DESCRIPTION
## Overview
This PR fixes an issue where the user menu would not be displayed on compuclient sites and would throw a `Failed to find extension: uk.co.compucorp.usermenu` error.

## How it looks after the fix
![gif](https://user-images.githubusercontent.com/1642119/78161408-640d1100-7413-11ea-9e03-72405c65449e.gif)


## Technical Details

We find the module path using the full container instead of the default one so it can properly find the usermenu extension's path.

The issue is that the default container tries to search for the extension in the default extension folder, but compuclient uses a different path. The full container can find extensions that are both in this default folder and elsewhere.