### PR TITLE
CATL-1310: Fix home replacing

### DIFF
--- a/CRM/Usermenu/Hooks/CoreResourceList/HomeMenu.php
+++ b/CRM/Usermenu/Hooks/CoreResourceList/HomeMenu.php
@@ -33,8 +33,10 @@ class CRM_Usermenu_Hooks_CoreResourceList_HomeMenu extends BaseHook {
   /**
    * Determines if the function should run.
    *
-   * Runs when appending assets to the HTML header region, and when the
-   * Home Menu navigation item is set to active.
+   * Runs given the following conditions:
+   * - When appending assets to the HTML header region.
+   * - The Home Menu navigation item is set to active.
+   * - The user can access the Home Menu navigation item.
    *
    * @return bool
    *   True when the hook should run.
@@ -43,8 +45,9 @@ class CRM_Usermenu_Hooks_CoreResourceList_HomeMenu extends BaseHook {
     $homeMenu = $this->getHomeMenu();
     $isHeaderRegion = $this->region === 'html-header';
     $isHomeMenuActive = $homeMenu && $homeMenu['is_active'] == 1;
+    $canAccessHomeMenu = CRM_Core_BAO_Navigation::checkPermission($homeMenu);
 
-    return $isHeaderRegion && $isHomeMenuActive;
+    return $isHeaderRegion && $isHomeMenuActive && $canAccessHomeMenu;
   }
 
   /**

--- a/CRM/Usermenu/Hooks/CoreResourceList/UserMenu.php
+++ b/CRM/Usermenu/Hooks/CoreResourceList/UserMenu.php
@@ -18,8 +18,10 @@ class CRM_Usermenu_Hooks_CoreResourceList_UserMenu extends BaseHook {
   /**
    * Determines if the hook should run.
    *
-   * Runs when appending assets to the HTML header region and the user menu
-   * navigation item is active.
+   * Runs given the following conditions:
+   * - When appending assets to the HTML header region.
+   * - The User Menu navigation item is set to active.
+   * - The user can access the User Menu navigation item.
    *
    * @return bool
    *   True when the hook should run.
@@ -27,23 +29,26 @@ class CRM_Usermenu_Hooks_CoreResourceList_UserMenu extends BaseHook {
   protected function shouldRun() {
     $activeUserMenuItem = $this->getActiveUserMenu();
     $isHeaderRegion = $this->region === 'html-header';
-    $isUserMenuActive = $activeUserMenuItem['count'] > 0;
+    $isUserMenuActive = $activeUserMenuItem !== NULL;
+    $canAccessUserMenu = CRM_Core_BAO_Navigation::checkPermission($activeUserMenuItem);
 
-    return $isHeaderRegion && $isUserMenuActive;
+    return $isHeaderRegion && $isUserMenuActive && $canAccessUserMenu;
   }
 
   /**
    * Returns the User Menu navigation item if it's active.
    *
-   * @return array
-   *   The active user menu.
+   * @return array|null
+   *   The active user menu or null when not found.
    */
   private function getActiveUserMenu() {
-    return civicrm_api3('Navigation', 'get', [
+    $activeUserMenu = civicrm_api3('Navigation', 'get', [
       'is_active' => 1,
       'name' => 'user-menu-ext__user-menu',
       'options' => ['limit' => 1],
     ]);
+
+    return CRM_Utils_Array::first($activeUserMenu['values']);
   }
 
 }

--- a/CRM/Usermenu/Page/UserMenu.php
+++ b/CRM/Usermenu/Page/UserMenu.php
@@ -49,6 +49,10 @@ class CRM_Usermenu_Page_UserMenu extends CRM_Core_Page {
   /**
    * Returns the user menu navigation items.
    *
+   * Each menu item needs to support the following conditions:
+   * - Be active.
+   * - The current logged in user needs to have permissions to access the item.
+   *
    * @return array
    *   The user menu navigation items.
    */
@@ -59,7 +63,22 @@ class CRM_Usermenu_Page_UserMenu extends CRM_Core_Page {
       'options' => ['sort' => 'weight ASC'],
     ]);
 
-    return $menuItems['values'];
+    return $this->filterMenuItemsByPermission($menuItems['values']);
+  }
+
+  /**
+   * Filter the given menu items by permission.
+   *
+   * Only the menu items the user has permission to see will be returned.
+   *
+   * @param array $menuItems
+   *   A list of menu items and their permissions.
+   *
+   * @return array
+   *   A filtered list of menu items.
+   */
+  private function filterMenuItemsByPermission(array $menuItems) {
+    return array_filter($menuItems, 'CRM_Core_BAO_Navigation::checkPermission');
   }
 
   /**

--- a/CRM/Usermenu/Upgrader/Setups/AddNavigationItems.php
+++ b/CRM/Usermenu/Upgrader/Setups/AddNavigationItems.php
@@ -23,18 +23,12 @@ class CRM_Usermenu_Upgrader_Setups_AddNavigationItems {
     $homeMenuValues = [
       'label' => 'Home',
       'name' => 'user-menu-ext__home-menu',
+      'icon' => 'fa fa-home',
       'url' => '/civicrm/dashboard?reset=1',
       'permission' => 'access CiviCRM',
       'is_active' => 1,
     ];
     $userMenuChildItemsValues = [
-      [
-        'label' => 'CiviCRM Home',
-        'name' => 'user-menu-ext__user-menu__civicrm-home',
-        'icon' => 'fa fa-home',
-        'url' => '/civicrm/dashboard?reset=1',
-        'is_active' => 1,
-      ],
       [
         'label' => 'My Account',
         'name' => 'user-menu-ext__user-menu__my-account',

--- a/js/homemenu.js
+++ b/js/homemenu.js
@@ -1,12 +1,17 @@
-(function ($, homeMenuItem) {
-  var $homeMenu, $homeMenuLink;
+(function ($, _, homeMenuItem) {
+  var $homeMenu, $homeMenuLink, isHomeMenuReplaced;
 
-  $(document).ready(function () {
-    $homeMenu = $('#civicrm-menu [data-name="Home"]');
-    $homeMenuLink = $homeMenu.find('> a');
-
-    replaceHomeMenu();
-  });
+  /**
+   * We run the home menu replacing both on document ready and when the
+   * CiviCRM Menu has loaded because CiviCRM appends the menu at different times
+   * and we can't determine when it was appended.
+   *
+   * See: https://github.com/civicrm/civicrm-core/blob/master/js/crm.menubar.js#L28-L44
+   */
+  (function init () {
+    $(document).ready(runHomeMenuReplacing);
+    $(document).on('crmLoad', '#civicrm-menu', runHomeMenuReplacing);
+  })();
 
   /**
    * Replaces the home menu with a custom one with the following features:
@@ -26,4 +31,26 @@
       .attr('href', homeMenuItem.url)
       .appendTo($homeMenu);
   }
-})(CRM.$, CRM['usermenu-ext__home-menu']);
+
+  /**
+   * Run the home menu replacing functions as long as the following is true:
+   *
+   * - The home menu is ready to be replaced. IE: it exists in the DOM.
+   * - The home menu has not been replaced already.
+   */
+  function runHomeMenuReplacing () {
+    var isHomeMenuReady;
+
+    $homeMenu = $('#civicrm-menu [data-name="Home"]');
+    $homeMenuLink = $homeMenu.find('> a');
+    isHomeMenuReady = $homeMenu.length > 0;
+
+    if (!isHomeMenuReady || isHomeMenuReplaced) {
+      return;
+    }
+
+    isHomeMenuReplaced = true;
+
+    replaceHomeMenu();
+  }
+})(CRM.$, CRM._, CRM['usermenu-ext__home-menu']);


### PR DESCRIPTION
## Overview
This PR fixes certain scenarios where the home menu replacement would not happen.

It also adds the following changes:
- It removes the Home menu item from the user menu since this menu item was not required.
- On the user menu, it will only display navigation items that the user can access due to permissions.
- It will only append the user menu, or alter the home menu if the user can access the navigation items related to these features.

## Before & After screens

### Running the home menu replacement

#### before
![gif](https://user-images.githubusercontent.com/1642119/79292066-378ad780-7e9e-11ea-95e7-99984e14686a.gif)

#### After
![gif](https://user-images.githubusercontent.com/1642119/79291525-e201fb00-7e9c-11ea-8f3f-ce536910e66a.gif)

### User menu items access

Setup: the "My Cases" navigation item can only be accessed with the "Administer CiviCRM" permission.

#### Admin User
![Screen Shot 2020-04-14 at 10 13 39 PM](https://user-images.githubusercontent.com/1642119/79291662-3b6a2a00-7e9d-11ea-9549-eb8ed9df5bea.png)

#### Award User
![Screen Shot 2020-04-14 at 10 15 01 PM](https://user-images.githubusercontent.com/1642119/79291736-694f6e80-7e9d-11ea-9bcc-ed0061b79d10.png)

### Hiding user and home menus when user has no permission to access them

Setup: Both menus can only be accessed with the "Administer CiviCRM" permission.

#### Admin User
![Screen Shot 2020-04-14 at 10 18 25 PM](https://user-images.githubusercontent.com/1642119/79291950-f98db380-7e9d-11ea-9772-d7aa4ae7b7b6.png)

#### Award User
![Screen Shot 2020-04-14 at 10 19 01 PM](https://user-images.githubusercontent.com/1642119/79291967-014d5800-7e9e-11ea-95b1-4f24d85ca5fb.png)

## Technical Details

### Replacing the home menu

The problem happened because CiviCRM will dynamically load the CiviCRM Home Menu (`#civicrm-menu`) and depending on the state of the page at that time it will even append the menu before `$(document).ready` is triggered. More info here: https://github.com/civicrm/civicrm-core/blob/master/js/crm.menubar.js#L28-L44

It is not clear why they went for this approach, maybe they wanted to avoid a visual glitch and display the menu right away. Regardless of the reason the menu will be appended either when the `#crm-container` is available, or when the document is ready if the container was not ready by then. The bug was hard to catch because after the first page load the home menu is usually available on document ready.

To fix the issue we have made it so our home menu replacing function runs both on document ready and when the CiviCRM Home menu loads as triggered here: https://github.com/civicrm/civicrm-core/blob/master/js/crm.menubar.js#L50

We also take measures to avoid running the replacing function twice.

### Displaying the user menu items the user can access

We use the `CRM_Core_BAO_Navigation::checkPermission` core function to determine if the user can access the given navigation item. We filter each item using the PHP `array_filter` function.

### Hiding the extension for users that don't have access to the Home and User menu navigation items

We also used the `CRM_Core_BAO_Navigation::checkPermission` core function to determine if the assets for these functions should be appended.