### PR TITLE
CPS-174: Move "Find Menu Item" element to "Search" menu

### DIFF
--- a/js/homemenu.js
+++ b/js/homemenu.js
@@ -14,6 +14,16 @@
   })();
 
   /**
+   * Moves the "Find Menu Item" element to the "Search" menu.
+   */
+  function moveFindMenuItemToSearchMenu () {
+    var $findMenuItem = $homeMenu.find('[data-name="MenubarDrillDown"]').clone();
+    var $searchMenuDropdown = $('[data-name="Search"] > ul');
+
+    $findMenuItem.prependTo($searchMenuDropdown);
+  }
+
+  /**
    * Replaces the home menu with a custom one with the following features:
    *
    * - Removes the dropdown menu.
@@ -52,5 +62,6 @@
     isHomeMenuReplaced = true;
 
     replaceHomeMenu();
+    moveFindMenuItemToSearchMenu();
   }
 })(CRM.$, CRM._, CRM['usermenu-ext__home-menu']);


### PR DESCRIPTION
## Overview
This PR moves the "Find Menu Item" element that was located in the Home menu, and places it under the "Search" menu.

## Before
![gif](https://user-images.githubusercontent.com/1642119/80809459-b7e45480-8b8f-11ea-8288-f06a30b50e0c.gif)

## After
![gif](https://user-images.githubusercontent.com/1642119/80809300-5fad5280-8b8f-11ea-822c-9e104166429f.gif)


## Technical Details

We have added a `moveFindMenuItemToSearchMenu` on the `homemenu.js` file. This function takes care of cloning the original "Find Menu Item" element, and prepends the clone to the "Search" menu. Since we never remove the original Home menu, but just hide it, then cloning works. Also, the events are attached to the `#civicrm-menu`, not to the actual element. Since the clone is still inside `#civicrm-menu` then everything works as normal.