### PR TITLE
Update usermenu.civix.php

### DIFF
--- a/usermenu.civix.php
+++ b/usermenu.civix.php
@@ -244,7 +244,7 @@ function _usermenu_civix_find_files($dir, $pattern) {
     if ($dh = opendir($subdir)) {
       while (FALSE !== ($entry = readdir($dh))) {
         $path = $subdir . DIRECTORY_SEPARATOR . $entry;
-        if ($entry{0} == '.') {
+        if ($entry[0] == '.') {
         }
         elseif (is_dir($path)) {
           $todos[] = $path;


### PR DESCRIPTION
Replaced curly braces with square braces for the array offset

## Overview
Curly braces are no longer allowed for array offsets in PHP (not sure which version that is, but I'm using 8.1.11)

## Before
When trying to install using `cv en`, I received the following error:

`PHP Fatal error:  Array and string offset access syntax with curly braces is no longer supported in drupal_site//htdocs/sites/default/files/civicrm/ext/uk.co.compucorp.usermenu/usermenu.civix.php on line 247`

## After
The only change was replacing curly braces with square braces.
