### PR TITLE
Update usermenu.civix.php

### DIFF
--- a/usermenu.civix.php
+++ b/usermenu.civix.php
@@ -244,7 +244,7 @@ function _usermenu_civix_find_files($dir, $pattern) {
     if ($dh = opendir($subdir)) {
       while (FALSE !== ($entry = readdir($dh))) {
         $path = $subdir . DIRECTORY_SEPARATOR . $entry;
-        if ($entry{0} == '.') {
+        if ($entry[0] == '.') {
         }
         elseif (is_dir($path)) {
           $todos[] = $path;


### PR DESCRIPTION
Fixed curly brace issue

## Overview
The code in the file as is throws an error in PHP 8.x (this was deprecated in PHP 7.4)

## Before
The check against the first element in the entry array uses curly braces for indexing, instead of square brackets.

## After
Changed to use square brackets, to conform to newer needs for Drupal 8